### PR TITLE
fix: workflow labeler path

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -11,4 +11,4 @@ jobs:
     steps:
       - uses: actions/labeler@v5
         with:
-          configuration-path: .github/configs/labeler.yml
+          configuration-path: .github/labeler.yml


### PR DESCRIPTION
related: #39 
失敗してるCIを直す