### PR TITLE
Sunshine API 使用時に使用回数をカウントする機能の追加

### DIFF
--- a/apps/api/src/features/sunshines/sunshine.controller.ts
+++ b/apps/api/src/features/sunshines/sunshine.controller.ts
@@ -11,9 +11,8 @@ export class SunshineController {
     try {
       const dto = (await c.req.json()) as SunshineTextDTO
 
-      // TODO: get userId and apiKeyId from the request
-      const userId = 'userId'
-      const apiKeyId = 'apiKeyId'
+      const userId = c.get('userId') as string
+      const apiKeyId = c.get('apiKeyId') as string
 
       const result = await this.sunshineUseCase.sunshineText({
         ...dto,

--- a/apps/api/src/features/sunshines/sunshine.route.ts
+++ b/apps/api/src/features/sunshines/sunshine.route.ts
@@ -7,7 +7,12 @@ import { getEnv } from '~/config/environment'
 import { SunshineController } from '~/features/sunshines/sunshine.controller'
 import { SunshineService } from '~/features/sunshines/sunshine.service'
 import { SunshineUseCase } from '~/features/sunshines/sunshine.usecase'
+import { UsageLogRepository } from '~/features/usageLogs/usageLog.repository'
+import { UsageLogService } from '~/features/usageLogs/usageLog.service'
+import { UserPlanRepository } from '~/features/userPlans/userPlan.repository'
+import { UserPlanService } from '~/features/userPlans/userPlan.service'
 import { OpenAIClient } from '~/libs/openai'
+import { SupabaseClient } from '~/libs/supabase'
 
 /**
  * Sunshine APIのルーティングを定義します
@@ -28,6 +33,22 @@ sunshineRoutes.post(
     return new SunshineController(
       new SunshineUseCase(
         new SunshineService(OpenAIClient(getEnv(c).OPENAI_API_KEY)),
+        new UserPlanService(
+          new UserPlanRepository(
+            SupabaseClient(
+              getEnv(c).SUPABASE_URL,
+              getEnv(c).SUPABASE_SERVICE_ROLE_KEY,
+            ),
+          ),
+        ),
+        new UsageLogService(
+          new UsageLogRepository(
+            SupabaseClient(
+              getEnv(c).SUPABASE_URL,
+              getEnv(c).SUPABASE_SERVICE_ROLE_KEY,
+            ),
+          ),
+        ),
       ),
     ).sunshineText(c)
   },

--- a/apps/api/src/features/sunshines/sunshine.usecase.ts
+++ b/apps/api/src/features/sunshines/sunshine.usecase.ts
@@ -5,27 +5,33 @@ import {
 import { failure, success, type Result } from '@peace-net/shared/utils/result'
 
 import { ISunshineService } from '~/features/sunshines/sunshine.service'
+import { IUsageLogService } from '~/features/usageLogs/usageLog.service'
+import { IUserPlanService } from '~/features/userPlans/userPlan.service'
 
 export interface ISunshineUseCase {
   sunshineText(input: SunshineTextInput): Promise<Result<SunshineResult>>
 }
 
 export class SunshineUseCase implements ISunshineUseCase {
-  constructor(private SunshineService: ISunshineService) {}
+  constructor(
+    private SunshineService: ISunshineService,
+    private userPlanService: IUserPlanService,
+    private usageLogService: IUsageLogService,
+  ) {}
 
   async sunshineText(
     input: SunshineTextInput,
   ): Promise<Result<SunshineResult>> {
     try {
-      const { text } = input
+      const { text, userId, apiKeyId } = input
       const result = await this.SunshineService.sunshineText(text)
 
-      // TODO: increment user plans total requests used
-      // await this.userPlanService.incrementTotalRequestsUsed(userId)
+      // increment user plans total requests used
+      await this.userPlanService.incrementTotalRequestsUsed(userId)
 
-      // TODO: increment usage logs
-      // TODO: update api keys last used
-      // await this.usageLogService.incrementUsageLog(apiKeyId, 'guardians')
+      // increment usage logs
+      // update api keys last used
+      await this.usageLogService.incrementUsageLog(apiKeyId, 'sunshines')
 
       return success({
         text: result.text,


### PR DESCRIPTION
- get userId and apiKeyId from the request
- increment user plans total requests used
- increment usage logs
- update api keys last used