### PR TITLE
Implement UsageFacade for centralized usage tracking

### DIFF
--- a/apps/api/src/features/guardians/guardian.route.ts
+++ b/apps/api/src/features/guardians/guardian.route.ts
@@ -12,6 +12,7 @@ import { GuardianService } from '~/features/guardians/guardian.service'
 import { GuardianUseCase } from '~/features/guardians/guardian.usecase'
 import { UsageLogRepository } from '~/features/usageLogs/usageLog.repository'
 import { UsageLogService } from '~/features/usageLogs/usageLog.service'
+import { UsageFacade } from '~/features/usages/usage.facade'
 import { UserPlanRepository } from '~/features/userPlans/userPlan.repository'
 import { UserPlanService } from '~/features/userPlans/userPlan.service'
 import { OpenAIClient } from '~/libs/openai'
@@ -37,19 +38,21 @@ guardianRoutes.post(
     return new GuardianController(
       new GuardianUseCase(
         new GuardianService(OpenAIClient(getEnv(c).OPENAI_API_KEY)),
-        new UserPlanService(
-          new UserPlanRepository(
-            SupabaseClient(
-              getEnv(c).SUPABASE_URL,
-              getEnv(c).SUPABASE_SERVICE_ROLE_KEY,
+        new UsageFacade(
+          new UserPlanService(
+            new UserPlanRepository(
+              SupabaseClient(
+                getEnv(c).SUPABASE_URL,
+                getEnv(c).SUPABASE_SERVICE_ROLE_KEY,
+              ),
             ),
           ),
-        ),
-        new UsageLogService(
-          new UsageLogRepository(
-            SupabaseClient(
-              getEnv(c).SUPABASE_URL,
-              getEnv(c).SUPABASE_SERVICE_ROLE_KEY,
+          new UsageLogService(
+            new UsageLogRepository(
+              SupabaseClient(
+                getEnv(c).SUPABASE_URL,
+                getEnv(c).SUPABASE_SERVICE_ROLE_KEY,
+              ),
             ),
           ),
         ),
@@ -70,19 +73,21 @@ guardianRoutes.post(
     return new GuardianController(
       new GuardianUseCase(
         new GuardianService(OpenAIClient(getEnv(c).OPENAI_API_KEY)),
-        new UserPlanService(
-          new UserPlanRepository(
-            SupabaseClient(
-              getEnv(c).SUPABASE_URL,
-              getEnv(c).SUPABASE_SERVICE_ROLE_KEY,
+        new UsageFacade(
+          new UserPlanService(
+            new UserPlanRepository(
+              SupabaseClient(
+                getEnv(c).SUPABASE_URL,
+                getEnv(c).SUPABASE_SERVICE_ROLE_KEY,
+              ),
             ),
           ),
-        ),
-        new UsageLogService(
-          new UsageLogRepository(
-            SupabaseClient(
-              getEnv(c).SUPABASE_URL,
-              getEnv(c).SUPABASE_SERVICE_ROLE_KEY,
+          new UsageLogService(
+            new UsageLogRepository(
+              SupabaseClient(
+                getEnv(c).SUPABASE_URL,
+                getEnv(c).SUPABASE_SERVICE_ROLE_KEY,
+              ),
             ),
           ),
         ),

--- a/apps/api/src/features/guardians/guardian.usecase.ts
+++ b/apps/api/src/features/guardians/guardian.usecase.ts
@@ -9,8 +9,7 @@ import {
   checkFlagged,
   createCategories,
 } from '~/features/guardians/guardian.utils'
-import { IUsageLogService } from '~/features/usageLogs/usageLog.service'
-import { IUserPlanService } from '~/features/userPlans/userPlan.service'
+import { IUsageFacade } from '~/features/usages/usage.facade'
 
 /**
  * テキストの不適切な内容を分析し、カテゴリー別のスコアを提供するユースケースのインターフェース
@@ -42,8 +41,7 @@ export interface IGuardianUseCase {
 export class GuardianUseCase implements IGuardianUseCase {
   constructor(
     private guardianService: IGuardianService,
-    private userPlanService: IUserPlanService,
-    private usageLogService: IUsageLogService,
+    private usageFacade: IUsageFacade,
   ) {}
 
   async guardianText(
@@ -57,12 +55,7 @@ export class GuardianUseCase implements IGuardianUseCase {
 
       const categories = createCategories(categoryScores, score_threshold)
 
-      // increment user plans total requests used
-      await this.userPlanService.incrementTotalRequestsUsed(userId)
-
-      // increment usage logs
-      // update api keys last used
-      await this.usageLogService.incrementUsageLog(apiKeyId, 'guardians')
+      await this.usageFacade.incrementUsage(userId, apiKeyId, 'guardians')
 
       return success({
         flagged,

--- a/apps/api/src/features/sunshines/sunshine.route.ts
+++ b/apps/api/src/features/sunshines/sunshine.route.ts
@@ -9,6 +9,7 @@ import { SunshineService } from '~/features/sunshines/sunshine.service'
 import { SunshineUseCase } from '~/features/sunshines/sunshine.usecase'
 import { UsageLogRepository } from '~/features/usageLogs/usageLog.repository'
 import { UsageLogService } from '~/features/usageLogs/usageLog.service'
+import { UsageFacade } from '~/features/usages/usage.facade'
 import { UserPlanRepository } from '~/features/userPlans/userPlan.repository'
 import { UserPlanService } from '~/features/userPlans/userPlan.service'
 import { OpenAIClient } from '~/libs/openai'
@@ -33,19 +34,21 @@ sunshineRoutes.post(
     return new SunshineController(
       new SunshineUseCase(
         new SunshineService(OpenAIClient(getEnv(c).OPENAI_API_KEY)),
-        new UserPlanService(
-          new UserPlanRepository(
-            SupabaseClient(
-              getEnv(c).SUPABASE_URL,
-              getEnv(c).SUPABASE_SERVICE_ROLE_KEY,
+        new UsageFacade(
+          new UserPlanService(
+            new UserPlanRepository(
+              SupabaseClient(
+                getEnv(c).SUPABASE_URL,
+                getEnv(c).SUPABASE_SERVICE_ROLE_KEY,
+              ),
             ),
           ),
-        ),
-        new UsageLogService(
-          new UsageLogRepository(
-            SupabaseClient(
-              getEnv(c).SUPABASE_URL,
-              getEnv(c).SUPABASE_SERVICE_ROLE_KEY,
+          new UsageLogService(
+            new UsageLogRepository(
+              SupabaseClient(
+                getEnv(c).SUPABASE_URL,
+                getEnv(c).SUPABASE_SERVICE_ROLE_KEY,
+              ),
             ),
           ),
         ),

--- a/apps/api/src/features/sunshines/sunshine.usecase.ts
+++ b/apps/api/src/features/sunshines/sunshine.usecase.ts
@@ -5,8 +5,7 @@ import {
 import { failure, success, type Result } from '@peace-net/shared/utils/result'
 
 import { ISunshineService } from '~/features/sunshines/sunshine.service'
-import { IUsageLogService } from '~/features/usageLogs/usageLog.service'
-import { IUserPlanService } from '~/features/userPlans/userPlan.service'
+import { IUsageFacade } from '~/features/usages/usage.facade'
 
 export interface ISunshineUseCase {
   sunshineText(input: SunshineTextInput): Promise<Result<SunshineResult>>
@@ -15,8 +14,7 @@ export interface ISunshineUseCase {
 export class SunshineUseCase implements ISunshineUseCase {
   constructor(
     private SunshineService: ISunshineService,
-    private userPlanService: IUserPlanService,
-    private usageLogService: IUsageLogService,
+    private usageFacade: IUsageFacade,
   ) {}
 
   async sunshineText(
@@ -26,12 +24,7 @@ export class SunshineUseCase implements ISunshineUseCase {
       const { text, userId, apiKeyId } = input
       const result = await this.SunshineService.sunshineText(text)
 
-      // increment user plans total requests used
-      await this.userPlanService.incrementTotalRequestsUsed(userId)
-
-      // increment usage logs
-      // update api keys last used
-      await this.usageLogService.incrementUsageLog(apiKeyId, 'sunshines')
+      await this.usageFacade.incrementUsage(userId, apiKeyId, 'sunshines')
 
       return success({
         text: result.text,

--- a/apps/api/src/features/usages/usage.facade.ts
+++ b/apps/api/src/features/usages/usage.facade.ts
@@ -1,0 +1,28 @@
+import { IUsageLogService } from '~/features/usageLogs/usageLog.service'
+import { IUserPlanService } from '~/features/userPlans/userPlan.service'
+
+export interface IUsageFacade {
+  incrementUsage(
+    userId: string,
+    apiKeyId: string,
+    feature: 'guardians' | 'sunshines',
+  ): Promise<void>
+}
+
+export class UsageFacade implements IUsageFacade {
+  constructor(
+    private userPlanService: IUserPlanService,
+    private usageLogService: IUsageLogService,
+  ) {}
+
+  async incrementUsage(
+    userId: string,
+    apiKeyId: string,
+    feature: 'guardians' | 'sunshines',
+  ): Promise<void> {
+    await Promise.all([
+      this.userPlanService.incrementTotalRequestsUsed(userId),
+      this.usageLogService.incrementUsageLog(apiKeyId, feature),
+    ])
+  }
+}


### PR DESCRIPTION
UsageFacadeを導入。
GuardianUseCaseとSunshineUseCaseで重複していたコードを削除し、使用状況の更新ロジックをカプセル化
[Facadeパターン](https://qiita.com/aconit96/items/60c924dbc69a059e5746)