### PR TITLE
fix: moving guardian to sunshine link

### DIFF
--- a/apps/docs/sidebars.ts
+++ b/apps/docs/sidebars.ts
@@ -23,7 +23,6 @@ const sidebars: SidebarsConfig = {
     {
       type: 'category',
       label: '機能',
-      link: { type: 'doc', id: 'features/guardian' },
       items: ['features/guardian', 'features/sunshine'],
     },
     {


### PR DESCRIPTION
画面遷移のバグを修正