### PR TITLE
Guardian APIにAIのモデルを選択できるオプションを追加

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -8,6 +8,8 @@
     "lint": "eslint src --ext .ts,.tsx"
   },
   "dependencies": {
+    "@ai-sdk/anthropic": "^0.0.43",
+    "@ai-sdk/google": "^0.0.39",
     "@ai-sdk/openai": "^0.0.46",
     "@hono/zod-validator": "^0.2.2",
     "@peace-net/shared": "workspace:*",

--- a/apps/api/src/config/environment.ts
+++ b/apps/api/src/config/environment.ts
@@ -6,6 +6,8 @@ import { z } from 'zod'
 const envSchema = z.object({
   DOCS_URL: z.string(),
   OPENAI_API_KEY: z.string(),
+  ANTHROPIC_API_KEY: z.string(),
+  GOOGLE_API_KEY: z.string(),
   SUPABASE_URL: z.string(),
   SUPABASE_SERVICE_ROLE_KEY: z.string(),
   ENCRYPTION_KEY: z.string(),

--- a/apps/api/src/features/guardians/guardian.route.ts
+++ b/apps/api/src/features/guardians/guardian.route.ts
@@ -15,6 +15,8 @@ import { UsageLogService } from '~/features/usageLogs/usageLog.service'
 import { UsageFacade } from '~/features/usages/usage.facade'
 import { UserPlanRepository } from '~/features/userPlans/userPlan.repository'
 import { UserPlanService } from '~/features/userPlans/userPlan.service'
+import { AnthropicClient } from '~/libs/anthropic'
+import { GoogleClient } from '~/libs/google'
 import { OpenAIClient } from '~/libs/openai'
 import { SupabaseClient } from '~/libs/supabase'
 
@@ -37,7 +39,11 @@ guardianRoutes.post(
   async (c) => {
     return new GuardianController(
       new GuardianUseCase(
-        new GuardianService(OpenAIClient(getEnv(c).OPENAI_API_KEY)),
+        new GuardianService(
+          OpenAIClient(getEnv(c).OPENAI_API_KEY),
+          AnthropicClient(getEnv(c).ANTHROPIC_API_KEY),
+          GoogleClient(getEnv(c).GOOGLE_API_KEY),
+        ),
         new UsageFacade(
           new UserPlanService(
             new UserPlanRepository(
@@ -72,7 +78,11 @@ guardianRoutes.post(
   async (c) => {
     return new GuardianController(
       new GuardianUseCase(
-        new GuardianService(OpenAIClient(getEnv(c).OPENAI_API_KEY)),
+        new GuardianService(
+          OpenAIClient(getEnv(c).OPENAI_API_KEY),
+          AnthropicClient(getEnv(c).ANTHROPIC_API_KEY),
+          GoogleClient(getEnv(c).GOOGLE_API_KEY),
+        ),
         new UsageFacade(
           new UserPlanService(
             new UserPlanRepository(

--- a/apps/api/src/features/guardians/guardian.usecase.ts
+++ b/apps/api/src/features/guardians/guardian.usecase.ts
@@ -48,8 +48,18 @@ export class GuardianUseCase implements IGuardianUseCase {
     input: GuardianTextInput,
   ): Promise<Result<GuardianResult>> {
     try {
-      const { text, score_threshold = 0.5, userId, apiKeyId } = input
-      const categoryScores = await this.guardianService.guardianText(text)
+      const {
+        text,
+        score_threshold = 0.5,
+        model = 'gpt-4o-mini',
+        userId,
+        apiKeyId,
+      } = input
+
+      const categoryScores = await this.guardianService.guardianText(
+        text,
+        model,
+      )
 
       const flagged = checkFlagged(categoryScores, score_threshold)
 

--- a/apps/api/src/libs/anthropic.ts
+++ b/apps/api/src/libs/anthropic.ts
@@ -1,0 +1,13 @@
+import { createAnthropic } from '@ai-sdk/anthropic'
+
+/**
+ * Anthropic APIのクライアントを生成します
+ *
+ * @param apiKey - Anthropic APIのAPIキー
+ * @returns Anthropic APIのクライアント
+ */
+export const AnthropicClient = (apiKey: string) => {
+  return createAnthropic({
+    apiKey,
+  })
+}

--- a/apps/api/src/libs/google.ts
+++ b/apps/api/src/libs/google.ts
@@ -1,0 +1,13 @@
+import { createGoogleGenerativeAI } from '@ai-sdk/google'
+
+/**
+ * Google Generative AI APIのクライアントを生成します
+ *
+ * @param apiKey - Google Generative AI APIのAPIキー
+ * @returns Google Generative AIのクライアント
+ */
+export const GoogleClient = (apiKey: string) => {
+  return createGoogleGenerativeAI({
+    apiKey,
+  })
+}

--- a/packages/shared/src/schemas/guardian.ts
+++ b/packages/shared/src/schemas/guardian.ts
@@ -8,9 +8,16 @@ export const categoryScoresSchema = z.object({
   defamation: z.number(),
 })
 
+export const modelsSchema = z.union([
+  z.literal('gpt-4o-mini'),
+  z.literal('claude-3-haiku'),
+  z.literal('gemini-1.5-flash'),
+])
+
 export const guardianTextRequestSchema = z.object({
   text: z.string().max(500),
   score_threshold: z.number().max(1).min(0).optional().default(0.5),
+  model: modelsSchema.optional().default('gpt-4o-mini'),
 })
 
 export const guardianImageRequestSchema = z.object({

--- a/packages/shared/src/types/guardian.ts
+++ b/packages/shared/src/types/guardian.ts
@@ -4,11 +4,14 @@ import {
   guardianTextRequestSchema,
   guardianImageRequestSchema,
   guardianResultSchema,
+  modelsSchema,
 } from '../schemas/guardian'
 
 export type Category = keyof z.infer<typeof categoryScoresSchema>
 
 export type CategoryScores = z.infer<typeof categoryScoresSchema>
+
+export type Models = z.infer<typeof modelsSchema>
 
 export type GuardianTextDTO = z.infer<typeof guardianTextRequestSchema>
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,12 @@ importers:
 
   apps/api:
     dependencies:
+      '@ai-sdk/anthropic':
+        specifier: ^0.0.43
+        version: 0.0.43(zod@3.23.8)
+      '@ai-sdk/google':
+        specifier: ^0.0.39
+        version: 0.0.39(zod@3.23.8)
       '@ai-sdk/openai':
         specifier: ^0.0.46
         version: 0.0.46(zod@3.23.8)
@@ -418,6 +424,18 @@ packages:
     resolution: {integrity: sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==}
     engines: {node: '>=0.10.0'}
 
+  '@ai-sdk/anthropic@0.0.43':
+    resolution: {integrity: sha512-X9GBINVeaynnpSETD6rBgkmkR5VynceyVe8FxDCM+5jQF9fNNPCpaXX/syE9G8HH941HGFdEcFuGuLR6MvNdeA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.0.0
+
+  '@ai-sdk/google@0.0.39':
+    resolution: {integrity: sha512-++IRoxi37DaqxGv5+zFwYFc4v9UT2r5Ac4d66kxjiQ1Gj5ACYWzaLzPrJJuBOhlO8Y8f20Lx3kNR5bPb0LkU8w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.0.0
+
   '@ai-sdk/openai@0.0.46':
     resolution: {integrity: sha512-RdE/PjdGt5zeE19qd/aqEr6fz6lhA5IWzBMy+N3dkdGtijT+eJP7Kxta6lYwnevkr1yqRPXYkYX/6v/s6xVY4A==}
     engines: {node: '>=18'}
@@ -433,8 +451,21 @@ packages:
       zod:
         optional: true
 
+  '@ai-sdk/provider-utils@1.0.13':
+    resolution: {integrity: sha512-NDQUUBDQoWk9aGn2pOA5wiM5CdO57KeYTEph7PpKGEU8IyqI0d+CiYKISOia6Omy17d+Dw/ZM6KP98F89BGJ5A==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
   '@ai-sdk/provider@0.0.19':
     resolution: {integrity: sha512-WXyyJ0Fqg0OHzUQ/spem4jRFPq+NkYB8YNTVbSQrE+Rpxtm7DqK1x9MrHtIEhoikCMg9wBOCbm7HuMnfsIR5GA==}
+    engines: {node: '>=18'}
+
+  '@ai-sdk/provider@0.0.20':
+    resolution: {integrity: sha512-nCQZRUTi/+y+kf1ep9rujpbQEtsIwySzlQAudiFeVhzzDi9rYvWp5tOSVu8/ArT+i1xSc2tw40akxb1TX73ofQ==}
     engines: {node: '>=18'}
 
   '@ai-sdk/react@0.0.43':
@@ -8625,6 +8656,18 @@ snapshots:
 
   '@aashutoshrathi/word-wrap@1.2.6': {}
 
+  '@ai-sdk/anthropic@0.0.43(zod@3.23.8)':
+    dependencies:
+      '@ai-sdk/provider': 0.0.20
+      '@ai-sdk/provider-utils': 1.0.13(zod@3.23.8)
+      zod: 3.23.8
+
+  '@ai-sdk/google@0.0.39(zod@3.23.8)':
+    dependencies:
+      '@ai-sdk/provider': 0.0.20
+      '@ai-sdk/provider-utils': 1.0.13(zod@3.23.8)
+      zod: 3.23.8
+
   '@ai-sdk/openai@0.0.46(zod@3.23.8)':
     dependencies:
       '@ai-sdk/provider': 0.0.19
@@ -8640,7 +8683,20 @@ snapshots:
     optionalDependencies:
       zod: 3.23.8
 
+  '@ai-sdk/provider-utils@1.0.13(zod@3.23.8)':
+    dependencies:
+      '@ai-sdk/provider': 0.0.20
+      eventsource-parser: 1.1.2
+      nanoid: 3.3.6
+      secure-json-parse: 2.7.0
+    optionalDependencies:
+      zod: 3.23.8
+
   '@ai-sdk/provider@0.0.19':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/provider@0.0.20':
     dependencies:
       json-schema: 0.4.0
 


### PR DESCRIPTION
## 選択可能なモデル

1. gpt-4o-mini
2. claude-3-haiku
3. gemini-1.5-flash

## モデルごとのレスポンス時間（ローカル）

### gpt-4o-mini

1. `1108`ms
2. `961`ms
3. `1217`ms

### claude-3-haiku

1. `1442`ms
4. `1379`ms
5. `1429`ms

### gemini-1.5-flash

1. `835`ms
6. `917`ms
7. `840`ms

## 選択不可能なモデルを入力した際のエラー

### リクエスト例
```json
{
    "text": "バカ",
    "score_threshold": 0.5,
    "model": "gpt-4-turbo"
}
```

### レスポンス
```json
{
    "error": "[Peace Net]: Invalid Input Error",
    "details": [
        {
            "path": [
                "model"
            ],
            "message": "Invalid input",
            "code": "invalid_union"
        }
    ],
    "status": 400
}
```

## テストの追加
何すればよいかわかんない😇