### PR TITLE
feat: add renovate.json

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,11 +10,6 @@
         "groupName": "github actions deps"
       },
       {
-        "matchManagers": ["dockerfile"],
-        "matchUpdateTypes": ["minor", "patch"],
-        "groupName": "docker deps"
-      },
-      {
         "matchManagers": ["npm"],
         "matchUpdateTypes": ["minor", "patch"],
         "groupName": "npm deps"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,10 +14,5 @@
         "matchUpdateTypes": ["minor", "patch"],
         "groupName": "npm deps"
       },
-      {
-        "matchManagers": ["gomod"],
-        "matchUpdateTypes": ["minor", "patch"],
-        "groupName": "go deps"
-      }
     ]
   }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,28 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": ["config:base", ":disableDependencyDashboard"],
+    "timezone": "Asia/Tokyo",
+    "prConcurrentLimit": 5,
+    "packageRules": [
+      {
+        "matchManagers": ["github-actions"],
+        "matchUpdateTypes": ["minor", "patch"],
+        "groupName": "github actions deps"
+      },
+      {
+        "matchManagers": ["dockerfile"],
+        "matchUpdateTypes": ["minor", "patch"],
+        "groupName": "docker deps"
+      },
+      {
+        "matchManagers": ["npm"],
+        "matchUpdateTypes": ["minor", "patch"],
+        "groupName": "npm deps"
+      },
+      {
+        "matchManagers": ["gomod"],
+        "matchUpdateTypes": ["minor", "patch"],
+        "groupName": "go deps"
+      }
+    ]
+  }


### PR DESCRIPTION
参考サイト：https://book.st-hakky.com/hakky/how-to-setup-renovate/

renovate.jsonファイルを追加、追記してます。
ファイルの中身は、とりあえず参考サイト通りにしてます。

自動管理してほしい「パッケージマネージャー」を追加していく流れになります。
今回は、「github-actions、dockerfile、npm、gomod」を設定してます。

今後、追加予定です。