### PR TITLE
feat: wrangler logs enable

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -23,6 +23,6 @@
     "@cloudflare/workers-types": "^4.20240529.0",
     "@peace-net/eslint-config": "workspace:*",
     "@peace-net/typescript-config": "workspace:*",
-    "wrangler": "^3.57.2"
+    "wrangler": "^3.78.12"
   }
 }

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -9,6 +9,10 @@ route = { pattern = "api.pe-ace.net", custom_domain = true }
 [vars]
 DOCS_URL = "https://docs.pe-ace.net/"
 
+[observability]
+enabled = true
+head_sampling_rate = 1
+
 # [[kv_namespaces]]
 # binding = "MY_KV_NAMESPACE"
 # id = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,7 +70,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/typescript-config
       wrangler:
-        specifier: ^3.57.2
+        specifier: ^3.78.12
         version: 3.78.12(@cloudflare/workers-types@4.20240925.0)
 
   apps/docs:
@@ -10407,7 +10407,7 @@ snapshots:
 
   '@docusaurus/react-loadable@6.0.0(react@18.3.1)':
     dependencies:
-      '@types/react': 18.3.4
+      '@types/react': 18.3.10
       react: 18.3.1
 
   '@docusaurus/theme-classic@3.5.2(@types/react@18.3.10)(eslint@8.57.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.2)':
@@ -10860,7 +10860,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 22.7.4
+      '@types/node': 20.16.10
       '@types/yargs': 17.0.33
       chalk: 4.1.2
 
@@ -11846,7 +11846,7 @@ snapshots:
   '@types/body-parser@1.19.5':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 22.7.4
+      '@types/node': 20.16.10
 
   '@types/bonjour@3.5.13':
     dependencies:
@@ -11859,7 +11859,7 @@ snapshots:
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 22.7.4
+      '@types/node': 20.16.10
 
   '@types/crypto-js@4.2.2': {}
 
@@ -11908,7 +11908,7 @@ snapshots:
 
   '@types/express-serve-static-core@4.19.5':
     dependencies:
-      '@types/node': 22.7.4
+      '@types/node': 20.16.10
       '@types/qs': 6.9.15
       '@types/range-parser': 1.2.7
       '@types/send': 0.17.4
@@ -11945,7 +11945,7 @@ snapshots:
 
   '@types/http-proxy@1.17.15':
     dependencies:
-      '@types/node': 22.7.4
+      '@types/node': 20.16.10
 
   '@types/inquirer@6.5.0':
     dependencies:
@@ -11985,7 +11985,7 @@ snapshots:
 
   '@types/node-forge@1.3.11':
     dependencies:
-      '@types/node': 22.7.4
+      '@types/node': 20.16.10
 
   '@types/node@17.0.45': {}
 
@@ -12036,7 +12036,7 @@ snapshots:
   '@types/react-router@5.1.20':
     dependencies:
       '@types/history': 4.7.11
-      '@types/react': 18.3.4
+      '@types/react': 18.3.10
 
   '@types/react-syntax-highlighter@15.5.13':
     dependencies:
@@ -12056,7 +12056,7 @@ snapshots:
 
   '@types/sax@1.2.7':
     dependencies:
-      '@types/node': 22.7.4
+      '@types/node': 20.16.10
 
   '@types/semver@7.5.0': {}
 
@@ -12065,7 +12065,7 @@ snapshots:
   '@types/send@0.17.4':
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 22.7.4
+      '@types/node': 20.16.10
 
   '@types/serve-index@1.9.4':
     dependencies:
@@ -13802,7 +13802,7 @@ snapshots:
       has-property-descriptors: 1.0.1
       has-proto: 1.0.1
       has-symbols: 1.0.3
-      hasown: 2.0.0
+      hasown: 2.0.2
       internal-slot: 1.0.6
       is-array-buffer: 3.0.2
       is-callable: 1.2.7
@@ -13857,11 +13857,11 @@ snapshots:
     dependencies:
       get-intrinsic: 1.2.4
       has-tostringtag: 1.0.0
-      hasown: 2.0.0
+      hasown: 2.0.2
 
   es-shim-unscopables@1.0.2:
     dependencies:
-      hasown: 2.0.0
+      hasown: 2.0.2
 
   es-to-primitive@1.2.1:
     dependencies:
@@ -14623,7 +14623,7 @@ snapshots:
       function-bind: 1.1.2
       has-proto: 1.0.1
       has-symbols: 1.0.3
-      hasown: 2.0.0
+      hasown: 2.0.2
 
   get-intrinsic@1.2.4:
     dependencies:
@@ -15447,7 +15447,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 22.7.4
+      '@types/node': 20.16.10
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11


### PR DESCRIPTION
related: #197 

https://developers.cloudflare.com/workers/observability/logs/workers-logs/
workersのログが利用できるようになったので出してみる。

従来は有料プランが必要だったけど200,000 / dayまで無料枠なので1円も払わなくて済みそう 👍 